### PR TITLE
GithubPublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "build:staging": "webpack --config webpack.config.js --mode=development --env staging",
     "build": "webpack --config webpack.config.js --mode=development --env prod",
     "bundle": "webpack --config webpack.config.js --mode=production",
+    "copy": "cp package.json dist/ && cp README.md dist/ && cp -r license_output dist/",
+    "production": "npm run bundle && npm run copy",
     "test:unit": "NODE_ENV=test jest tests/App.test.js",
     "test:e2e": "playwright test tests/e2e.test.js"
   },


### PR DESCRIPTION
## Purpose
Added missing command to package.json to complement the publish action.

I think the reason the `dist` folder was empty is that we are running 'production' command, which was missing from the package.json. I copied the missing steps from the SplashScreen, I think that should rectify the issue.

![image](https://github.com/DynamoDS/DynamoHome/assets/5354594/253b10d3-a3bf-4783-a0dc-17d0eeb8df28)


## Changes
- following splashscreen example, added 'production' command to be ran in GitHub publish action

## Reviewers
@QilongTang 