### PR TITLE
License information workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "copy": "cp package.json dist/ && cp README.md dist/ && cp -r license_output dist/",
     "production": "npm run bundle && npm run copy",
     "test:unit": "NODE_ENV=test jest tests/App.test.js",
-    "test:e2e": "playwright test tests/e2e.test.js"
+    "test:e2e": "playwright test tests/e2e.test.js",
+    "lic_direct": "npx @adsk/adsk-npm-license-puller --path . --app-name 'home-page' --verbose --about-box ./license_output/about-box_direct.html --about-box-type desktop --year $(date \"+%Y\") --paos ./license_output/paos_direct.csv",
+    "lic_transitive": "npx @adsk/adsk-npm-license-puller --path . --app-name 'home-page' --verbose --about-box ./license_output/about-box_transitive.html --about-box-type desktop --transitive --year $(date \"+%Y\") --paos ./license_output/paos_transitive.csv",
+    "generate_license": "npm run lic_direct && npm run lic_transitive"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
## Purpose
Missing license information, trying to resolve that part of the publishing process.

Added the missing steps from SplashScreen.

## Changes
- following splashscreen example, added 'generate_license' command to be ran in GitHub publish action

## Reviewers
@QilongTang 