### PR TITLE
Root sample files

### DIFF
--- a/src/assets/samples.js
+++ b/src/assets/samples.js
@@ -4,6 +4,18 @@ export const samples = [
     FilePath: 'Path',
     Children: [
       {
+        FileName: 'loco.dyn',
+        FilePath:
+          'D:\\ProgramData\\Autodesk\\RVT 2025\\Dynamo\\non-samples\\Loco_file.dyn',
+        Children: null
+      },
+      {
+        FileName: 'lose.dyn',
+        FilePath:
+          'C:\\ProgramData\\Autodesk\\RVT 2025\\Dynamo\\samples\\Lose_file.dyn',
+        Children: null
+      },
+      {
         FileName: 'Basics',
         FilePath: 'C:\\ProgramData\\Autodesk\\RVT 2025\\Dynamo\\samples\\en-US\\Basics',
         Children: [

--- a/src/components/Samples/SamplesGrid.jsx
+++ b/src/components/Samples/SamplesGrid.jsx
@@ -24,7 +24,11 @@ const renderSample = (sample, key) => {
     } else {
         // Render a SamplesGridItem for leaf nodes
         return (
-            <SamplesGridItem key={key} FileName={sample.FileName} FilePath={sample.FilePath} />
+            <div className={styles["sample-container"]}>
+                <div className={styles["graphs-grid"]}>
+                    <SamplesGridItem key={key} FileName={sample.FileName} FilePath={sample.FilePath} />
+                </div>
+            </div>
         );
     }
 };


### PR DESCRIPTION
## Purpose
A small PR fixing the render of files inside the root Sample folder.

### UI Changes
![image](https://github.com/DynamoDS/DynamoHome/assets/5354594/eb034a28-60a2-4741-b91a-e30daea4b32e)

## Changes
- files in the root Sample folder would now render normal size when in grid mode

## Reviewer
@QilongTang