### PR TITLE
DYN-6857-homepage-preferences

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dynamods/dynamo-home",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dynamods/dynamo-home",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "react": "^18.2.0",
@@ -4327,13 +4327,13 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
       "dev": true,
       "dependencies": {
         "bytes": "3.1.2",
-        "content-type": "~1.0.4",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
@@ -4341,7 +4341,7 @@
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
         "qs": "6.11.0",
-        "raw-body": "2.5.1",
+        "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
       },
@@ -4822,9 +4822,9 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
@@ -6395,17 +6395,17 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -6627,9 +6627,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "dev": true,
       "funding": [
         {
@@ -11561,9 +11561,9 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "dev": true,
       "dependencies": {
         "bytes": "3.1.2",
@@ -13426,9 +13426,9 @@
       }
     },
     "node_modules/webpack-dev-middleware": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
-      "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+      "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
       "dev": true,
       "dependencies": {
         "colorette": "^2.0.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynamods/dynamo-home",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynamods/dynamo-home",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Dynamo Home",
   "author": "Autodesk Inc.",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynamods/dynamo-home",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Dynamo Home",
   "author": "Autodesk Inc.",
   "main": "index.js",

--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react';
 import { IntlProvider } from 'react-intl';
 import { getMessagesForLocale } from './localization/localization.js';
 import { LayoutContainer } from './components/LayoutContainer.jsx';
+import { SettingsProvider } from './components/SettingsContext.jsx';
 
 function App() {
   const [locale, setLocale] = useState('en');
@@ -23,7 +24,9 @@ function App() {
 
   return (
     <IntlProvider locale={locale} messages={messages}>
-      <LayoutContainer id='homeContainer' />
+      <SettingsProvider>
+        <LayoutContainer id='homeContainer' />
+      </SettingsProvider>
     </IntlProvider>
   );
 }

--- a/src/components/MainContent.jsx
+++ b/src/components/MainContent.jsx
@@ -6,19 +6,35 @@ import { FormattedMessage } from 'react-intl';
 
 export function MainContent({ selectedSidebarItem }){
     const [isDisabled, setIsDisabled] = useState(false);
+    const [settings, setSettings] = useState(null);
 
     const setShowStartPageChanged = (showStartPage) => {
         setIsDisabled(!showStartPage);
     };
 
+    const setHomePageSettings = (settingsJson) => {
+        try{
+            if (settingsJson) {
+                const settingsObject = JSON.parse(settingsJson);
+                setSettings(settingsObject);
+            } else {
+                console.log(`Received null or empty settings`);
+            }
+        }catch(exeption){
+            console.log($`Failed to set the HomePage settings with the following error ${exception}`);
+        }
+    }
+
     useEffect(() => {
-        // Set the setShowStartPageChanged global function
+        // Set global functions
         window.setShowStartPageChanged = setShowStartPageChanged;
+        window.setHomePageSettings = setHomePageSettings;
 
         return () => {
             delete window.setShowStartPageChanged;
+            delete window.setHomePageSettings;
         };
-    }, [isDisabled]); 
+    }, [isDisabled, settings]); 
 
     return (
         <>
@@ -31,10 +47,10 @@ export function MainContent({ selectedSidebarItem }){
                 )}
                 
                 <div className={`page-container ${selectedSidebarItem === 'Recent' ? '' : 'hidden'}`}>
-                    <RecentPage setIsDisabled={setIsDisabled} />
+                    <RecentPage setIsDisabled={setIsDisabled} recentPageViewMode={settings?.recentPageViewMode || "grid"} />
                 </div>
                 <div className={`page-container ${selectedSidebarItem === 'Samples' ? '' : 'hidden'}`}>
-                    <SamplesPage />
+                    <SamplesPage samplesViewMode={settings?.samplesViewMode || "grid"} />
                 </div>
                 <div className={`page-container ${selectedSidebarItem === 'Learning' ? '' : 'hidden'}`}>
                     <LearningPage />

--- a/src/components/Recent/CustomAuthorCellRenderer.jsx
+++ b/src/components/Recent/CustomAuthorCellRenderer.jsx
@@ -15,8 +15,6 @@ export const CustomAuthorCellRenderer = ({ value, row }) => {
   const author = value;
   const isOldFormat = author === intl.formatMessage({ id: 'recent.item.old.format' });
 
-  console.log(author);
-  console.log(isOldFormat);
   return (
     <div className={styles["title-cell"]}>
         <p>{author}</p>

--- a/src/components/Recent/PageRecent.jsx
+++ b/src/components/Recent/PageRecent.jsx
@@ -6,12 +6,15 @@ import { CustomLocationCellRenderer } from './CustomLocationCellRenderer.jsx';
 import { CustomAuthorCellRenderer } from "./CustomAuthorCellRenderer.jsx";
 import { GraphTable } from './GraphTable.jsx';
 import { GridViewIcon, ListViewIcon } from '../Common/CustomIcons.jsx';
-import { openFile } from '../../functions/utility.js';
+import { openFile, saveHomePageSettings } from '../../functions/utility.js';
 import { FormattedMessage } from 'react-intl';
 import { Tooltip } from '../Common/Tooltip.jsx';
+import { useSettings } from '../SettingsContext.jsx';
 
-export function RecentPage ({ setIsDisabled }){
-    const [viewMode, setViewMode] = useState('grid'); 
+export function RecentPage ({ setIsDisabled, recentPageViewMode }){    
+    const { settings, updateSettings } = useSettings();
+    const [viewMode, setViewMode] = useState(recentPageViewMode); 
+    const [initialized, setInitialized] = useState(false);
 
     // Set a placeholder for the graphs which will be used differently during dev and prod 
     let initialGraphs = [];
@@ -47,6 +50,21 @@ export function RecentPage ({ setIsDisabled }){
             }
         };
     }, []); 
+
+    useEffect(() => {
+        // Set the viewMode based on the HomePage preferences
+        setViewMode(recentPageViewMode);
+    }, [recentPageViewMode]); 
+
+    useEffect(() => {
+        if (initialized || recentPageViewMode !== viewMode) {
+            setInitialized(true);
+            updateSettings({ recentPageViewMode: viewMode });
+            
+            // Send settings to Dynamo to save
+            saveHomePageSettings({ ...settings, recentPageViewMode: viewMode });
+        } 
+    }, [viewMode]);
 
     // This variable defins the table structure displaying the graphs
     const columns = React.useMemo(() => [

--- a/src/components/Samples/PageSamples.jsx
+++ b/src/components/Samples/PageSamples.jsx
@@ -6,11 +6,14 @@ import { GridViewIcon, ListViewIcon } from '../Common/CustomIcons.jsx';
 import { Tooltip } from '../Common/Tooltip.jsx';
 import { CustomSampleFirstCellRenderer } from "./CustomSampleFirstCellRenderer.jsx";
 import { SamplesGrid } from './SamplesGrid.jsx';
-import { openFile, showSamplesFilesInFolder } from '../../functions/utility.js';
+import { openFile, showSamplesFilesInFolder, saveHomePageSettings } from '../../functions/utility.js';
+import { useSettings } from '../SettingsContext.jsx';
 
-export function SamplesPage (){
-    const [viewMode, setViewMode] = useState('grid'); 
+export function SamplesPage ({ samplesViewMode }){
+    const { settings, updateSettings } = useSettings();
+    const [viewMode, setViewMode] = useState(samplesViewMode); 
     const [collapsedRows, setCollapsedRows] = useState({});
+    const [initialized, setInitialized] = useState(false);
 
     // Set a placeholder for the graphs which will be used differently during dev and prod 
     let initialSamples = [];
@@ -50,6 +53,22 @@ export function SamplesPage (){
             }
         };
     }, []); 
+
+    
+    useEffect(() => {
+        // Set the viewMode based on the HomePage preferences
+        setViewMode(samplesViewMode);
+    }, [samplesViewMode]); 
+
+    useEffect(() => {
+        if (initialized || samplesViewMode !== viewMode) {
+            setInitialized(true);
+            updateSettings({ samplesViewMode: viewMode });
+            
+            // Send settings to Dynamo to save
+            saveHomePageSettings({ ...settings, samplesViewMode: viewMode });
+        } 
+    }, [viewMode]);
 
     // This variable defins the table structure displaying the graphs
     const columns = React.useMemo(() => [

--- a/src/components/SettingsContext.jsx
+++ b/src/components/SettingsContext.jsx
@@ -3,11 +3,11 @@ import React, { createContext, useContext, useState, useEffect } from 'react';
 // Create the context
 const SettingsContext = createContext();
 
-// Provider component that wraps your app components
+// Provider component that wraps the app components
 export function SettingsProvider({ children }) {
     const [settings, setSettings] = useState({});
 
-    // Function to update settings
+    // Update settings
     const updateSettings = (newSettings) => {
         setSettings(prev => ({ ...prev, ...newSettings }));
     };
@@ -19,7 +19,7 @@ export function SettingsProvider({ children }) {
     );
 }
 
-// Custom hook to use settings
+// Use settings hook
 export function useSettings() {
     return useContext(SettingsContext);
 }

--- a/src/components/SettingsContext.jsx
+++ b/src/components/SettingsContext.jsx
@@ -1,0 +1,25 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+// Create the context
+const SettingsContext = createContext();
+
+// Provider component that wraps your app components
+export function SettingsProvider({ children }) {
+    const [settings, setSettings] = useState({});
+
+    // Function to update settings
+    const updateSettings = (newSettings) => {
+        setSettings(prev => ({ ...prev, ...newSettings }));
+    };
+
+    return (
+        <SettingsContext.Provider value={{ settings, updateSettings }}>
+            {children}
+        </SettingsContext.Provider>
+    );
+}
+
+// Custom hook to use settings
+export function useSettings() {
+    return useContext(SettingsContext);
+}

--- a/src/functions/utility.js
+++ b/src/functions/utility.js
@@ -48,3 +48,13 @@ export function showSamplesFilesInFolder() {
     chrome.webview.hostObjects.scriptObject.ShowSampleFilesInFolder();
   }
 }
+
+/**
+ * A call to a backend function requesting to save the current HomePage settings
+ */
+export function saveHomePageSettings(settings) {
+  if (chrome.webview !== undefined) {
+    const settingsJson = JSON.stringify(settings);
+    chrome.webview.hostObjects.scriptObject.SaveSettings(settingsJson);
+  }
+}


### PR DESCRIPTION
## Purpose

This PR addresses a jira request for improvement of the HomePage: `As a Dynamo user, I want Grid/List view option picked on Dynamo Home persist across sessions` https://jira.autodesk.com/browse/DYN-6857.

> As a Dynamo user, I want Grid/List view option picked on Dynamo Home persist across sessions.
> 
> - Needs to be serialized
> - Needs to persist across session
> - Do not require user to set initial value
> - Preferred to be migrated with newer version of Dynamo launch
>
> We have examples in Preferences Settings just like this, e.g. Dynamo Window Default size, Dynamo Library Default size, etc. Although this setting is not expected to be exposed in settings panel
> 

Works with the following proposed Dynamo changes: https://github.com/DynamoDS/Dynamo/pull/15215

### Changes

![DynamoSandbox_rwEx2sI2K4](https://github.com/DynamoDS/DynamoHome/assets/5354594/6412191f-196f-483d-b70f-7c4062d536fb)

## Changes

- added preferences to track and persist across sessions the user preferences for the view mode of the Recent and Sample files
- version bump

## Reviewer
@QilongTang
@Amoursol 