### PR TITLE
 DYN-7034: Change default behavior pattern

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dynamods/dynamo-home",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dynamods/dynamo-home",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "license": "MIT",
       "dependencies": {
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynamods/dynamo-home",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Dynamo Home",
   "author": "Autodesk Inc.",
   "main": "index.js",

--- a/src/components/Samples/SamplesGrid.jsx
+++ b/src/components/Samples/SamplesGrid.jsx
@@ -2,14 +2,14 @@ import React from "react";
 import { SamplesGridItem } from "./SamplesGridItem";
 import styles from './SamplesGrid.module.css';
 
-const renderSample = (sample, key) => {
+const renderSample = (sample, keyPrefix) => {
     if (sample.Children && sample.Children.length > 0) {
         // Separate the children into leaf nodes and nested nodes
         const leafNodes = sample.Children.filter(child => !child.Children || child.Children.length === 0);
         const nestedNodes = sample.Children.filter(child => child.Children && child.Children.length > 0);
 
         return (
-            <div key={key} className={styles["sample-container"]}>
+            <div key={keyPrefix} className={styles["sample-container"]}>
                 <div className='drop-shadow-2xl'>
                     <p className='title-paragraph'>{sample.FileName}</p>
                 </div>
@@ -24,9 +24,9 @@ const renderSample = (sample, key) => {
     } else {
         // Render a SamplesGridItem for leaf nodes
         return (
-            <div className={styles["sample-container"]}>
+            <div key={keyPrefix} className={styles["sample-container"]}>
                 <div className={styles["graphs-grid"]}>
-                    <SamplesGridItem key={key} FileName={sample.FileName} FilePath={sample.FilePath} />
+                    <SamplesGridItem key={keyPrefix} FileName={sample.FileName} FilePath={sample.FilePath} />
                 </div>
             </div>
         );

--- a/src/components/Sidebar/CustomDropDown.jsx
+++ b/src/components/Sidebar/CustomDropDown.jsx
@@ -12,9 +12,7 @@ export const CustomDropdown = ({ id, selectedValue, options, onSelect, placehold
 
     /** Peforms the selected action type when used as a Drop-down */
     const handleOptionSelect = (option) => {
-        onSelect(option.label);
         setIsOpen(false);
-        setLastSelected(option); 
         if (onSelectionChange) {
             onSelectionChange(option.value); 
         }
@@ -22,11 +20,8 @@ export const CustomDropdown = ({ id, selectedValue, options, onSelect, placehold
 
     /** Peforms the selected action type when used as a Button */
     const handleDefaultAction = () => {
-        if (lastSelected) {
-            onSelect(lastSelected.label);
-            if (onSelectionChange) {
-                onSelectionChange(lastSelected.value);
-            }
+        if (onSelectionChange) {
+            onSelectionChange(lastSelected.value);
         }
     };
 

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -8,9 +8,6 @@ import styles from './Sidebar.module.css';
 
 export function Sidebar({ onItemSelect, selectedSidebarItem })
 {
-    const [selectedFile, setSelectedFile] = useState('');
-    const [selectedNew, setSelectedNew] = useState('');
-
     const isSelected = (item) => selectedSidebarItem === item;
 
     /**Trigger the backend command based on the drop-down value */ 
@@ -27,8 +24,6 @@ export function Sidebar({ onItemSelect, selectedSidebarItem })
                     {/* Files Dropdown */}
                     <CustomDropdown 
                         id="openDropdown"
-                        selectedValue={selectedFile}
-                        onSelect={setSelectedFile}
                         placeholder={<FormattedMessage id="button.title.text.open" />}
                         onSelectionChange={setSelectedValue}
                         options={[
@@ -41,8 +36,6 @@ export function Sidebar({ onItemSelect, selectedSidebarItem })
                     {/* New Dropdown */}
                     <CustomDropdown 
                         id="newDropdown"
-                        selectedValue={selectedNew}
-                        onSelect={setSelectedNew}
                         placeholder={<FormattedMessage id="button.title.text.new" />}
                         onSelectionChange={setSelectedValue}
                         options={[


### PR DESCRIPTION
## Purpose

This PR addresses the following jira issue: https://jira.autodesk.com/browse/DYN-7034 `Open and New dropdown button will not go back to the default behavior once the user chooses another option from the dropdown list`

## Changes

![DynamoSandbox_71idkVIsDH](https://github.com/DynamoDS/DynamoHome/assets/5354594/7b2d0c33-9907-4398-9df9-23a893f858e2)

- no longer 'remembers' the last default option used
- now always defaults to the first option for the respective drop-down button

## Reviewer

@reddyashish 
@avidit 