### PR TITLE
fix: set NODE_ENV as test before run test

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -40,10 +40,10 @@ jobs:
       - name: Build for production
         run: npm run production --if-present
       - name: Run Test
-        run: npm run test:unit
         env:
-          # Set environment to production just in case
-          NODE_ENV: production
+          # Set environment to test before run test
+          NODE_ENV: test
+        run: npm run test:unit
       - name: The final publish step within dist folder
         working-directory: dist
         # This will publish the package and set access to public as if you had run npm access public after publishing.

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -45,6 +45,7 @@ jobs:
           NODE_ENV: test
         run: npm run test:unit
       - name: The final publish step within dist folder
+        NODE_ENV: production
         working-directory: dist
         # This will publish the package and set access to public as if you had run npm access public after publishing.
         run: npm publish --access public


### PR DESCRIPTION
This is to set `NODE_ENV` as "test" before running tests on github action `npm-publish`.
@QilongTang PTAL