### PR TITLE
[DYN-7330] Dropdown button update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dynamods/dynamo-home",
-  "version": "1.0.17",
+  "version": "1.0.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dynamods/dynamo-home",
-      "version": "1.0.17",
+      "version": "1.0.19",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.14.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynamods/dynamo-home",
-  "version": "1.0.17",
+  "version": "1.0.19",
   "description": "Dynamo Home",
   "author": "Autodesk Inc.",
   "main": "index.tsx",

--- a/src/components/Samples/PageSamples.module.css
+++ b/src/components/Samples/PageSamples.module.css
@@ -1,0 +1,3 @@
+.wideDropdown {
+    width: 185px;
+}

--- a/src/components/Samples/PageSamples.tsx
+++ b/src/components/Samples/PageSamples.tsx
@@ -6,8 +6,10 @@ import { GridViewIcon, ListViewIcon } from '../Common/CustomIcons';
 import { Tooltip } from '../Common/Tooltip';
 import { CustomSampleFirstCellRenderer } from "./CustomSampleFirstCellRenderer";
 import { SamplesGrid } from './SamplesGrid';
-import { openFile, showSamplesFilesInFolder, saveHomePageSettings } from '../../functions/utility';
+import { openFile, showSamplesCommand, saveHomePageSettings } from '../../functions/utility';
 import { useSettings } from '../SettingsContext';
+import { CustomDropdown } from '../Sidebar/CustomDropDown';
+import styles from './PageSamples.module.css';
 
 export const SamplesPage = ({ samplesViewMode }) => {
     const { settings, updateSettings } = useSettings();
@@ -99,8 +101,8 @@ export const SamplesPage = ({ samplesViewMode }) => {
     };
 
     // Handles show samples link click
-    const handleShowSamplesClick = () => {
-        showSamplesFilesInFolder();
+    const handleShowSamplesClick = (value: ShowSamplesCommand) => {
+        showSamplesCommand(value);
     }
 
     return (
@@ -126,7 +128,19 @@ export const SamplesPage = ({ samplesViewMode }) => {
                     </Tooltip>
                 </button>
                 <div style={{ marginLeft: "auto", marginRight: "20px", color: "white" }}>
-                    <a id="showSampleFilesLink" style={{ cursor: "pointer", fontSize: "20px", color: "#6DD2FF" }} target="_blank" rel="noopener noreferrer" onClick={handleShowSamplesClick}><FormattedMessage id="samples.showsamples.text" /></a>
+                    <CustomDropdown
+                        id="samplesDropdown"
+                        placeholder={<FormattedMessage id="samples.showsamples.text" />}
+                        onSelectionChange={handleShowSamplesClick}
+                        options={[
+                            { label: <FormattedMessage id="samples.showsamples.files.text" />, value: 'open-graphs' },
+                            { label: <FormattedMessage id="samples.showsamples.datasets.text" />, value: 'open-datasets' }
+                        ]}
+                        className={styles.wideDropdown}
+                        showDivider={false}
+                        wholeButtonActionable={true}
+                        disableArrowHoverShadow={true}
+                    />
                 </div>
             </div>
             <div style={{ marginRight: "20px", paddingBottom: "35px" }}>

--- a/src/components/Sidebar/CustomDropDown.module.css
+++ b/src/components/Sidebar/CustomDropDown.module.css
@@ -114,3 +114,7 @@
     background-color: #9B9B9B; 
     margin: 0px; 
 }
+
+.no-hover-shadow .arrow-container:hover {
+    box-shadow: none !important;
+}

--- a/src/components/Sidebar/CustomDropDown.tsx
+++ b/src/components/Sidebar/CustomDropDown.tsx
@@ -2,7 +2,21 @@ import { useState, useRef, useEffect } from 'react';
 import styles from './CustomDropDown.module.css';
 import { OpenArrow } from '../Common/Arrow';
 
-export const CustomDropdown = ({ id, options, placeholder, onSelectionChange }: Dropdown) => {
+export const CustomDropdown = ({
+    id,
+    options,
+    placeholder,
+    onSelectionChange,
+    className,
+    showDivider = true,
+    wholeButtonActionable = false,
+    disableArrowHoverShadow = false
+}: Dropdown & {
+    className?: string,
+    showDivider?: boolean,
+    wholeButtonActionable?: boolean,
+    disableArrowHoverShadow?: boolean
+}) => {
     const [isOpen, setIsOpen] = useState(false);
     const [lastSelected, setLastSelected] = useState(options[0]);
     const dropdownRef = useRef(null);
@@ -43,14 +57,27 @@ export const CustomDropdown = ({ id, options, placeholder, onSelectionChange }: 
     }, [isOpen]);
 
     return (
-        <div className={`${styles['custom-dropdown']} ${isOpen ? styles.open : ''}`} ref={dropdownRef}>
-            <div className={styles['dropdown-selected']} onClick={handleDefaultAction}>
-                <span>{placeholder}</span>  
-                <span className={styles['vertical-line']}></span>
-                <div className={styles['arrow-container']} onClick={(e) => {
-                    e.stopPropagation(); 
-                    toggleDropdown();
-                }}>
+        <div
+            className={`
+            ${styles['custom-dropdown']} 
+            ${isOpen ? styles.open : ''} 
+            ${disableArrowHoverShadow ? styles['no-hover-shadow'] : ''} 
+            ${className}
+            `}
+            ref={dropdownRef}>
+            <div
+                className={styles['dropdown-selected']}
+                onClick={wholeButtonActionable ? toggleDropdown : undefined}
+            >
+                <span>{placeholder}</span>
+                {showDivider && <span className={styles['vertical-line']}></span>}
+                <div
+                    className={styles['arrow-container']}
+                    onClick={wholeButtonActionable ? undefined : (e) => {
+                        e.stopPropagation();
+                        toggleDropdown();
+                    }}
+                >
                     <OpenArrow isOpen={isOpen} color={arrowColor} />
                 </div>
             </div>

--- a/src/functions/utility.ts
+++ b/src/functions/utility.ts
@@ -19,7 +19,7 @@ export function startGuidedTour(guidedTour:string) {
 }
 
 /**
- * A call to different backedn functions based on the provided value
+ * A call to different backend functions based on the provided value
  * @param {SidebarCommand} value the type of command based on the UI request
  */
 export function sideBarCommand(value: SidebarCommand) {
@@ -41,11 +41,15 @@ export function sideBarCommand(value: SidebarCommand) {
 }
 
 /**
- * A call to a backend function requesting the execution of the ShowSampleFilesInFolder function
+ * A call to a backend functions based on the provided value
+ * * @param {ShowSamplesCommand} value the type of command based on the UI request
  */
-export function showSamplesFilesInFolder() {
-  if (window.chrome?.webview !== undefined) {
+export function showSamplesCommand(value: ShowSamplesCommand) {
+  if (value === 'open-graphs' && window.chrome?.webview !== undefined) {
     window.chrome.webview.hostObjects.scriptObject.ShowSampleFilesInFolder();
+  }
+  if (value === 'open-datasets' && window.chrome?.webview !== undefined) {
+    window.chrome.webview.hostObjects.scriptObject.ShowSampleDatasetsInFolder();
   }
 }
 

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -17,7 +17,9 @@
   "learning.title.text.learning": "Výuka",
   "learning.title.text.guides": "Interaktivní vodítka",
   "learning.title.text.videos": "Výukové videofilmy",
-  "samples.showsamples.text": "Zobrazit vzorky ve složce",
+  "samples.showsamples.text": "Otevřít umístění souboru",
+  "samples.showsamples.files.text": "Grafy",
+  "samples.showsamples.datasets.text": "Datové sady",
   "main.page.loading.text": "Načítání",
   "recent.item.old.format": "Formát souboru aplikace Dynamo 1.x",
   "recent.item.old.format.tooltip": "Pro soubory uložené ve formátu Dynamo 1.x není k dispozici autor ani miniatura."

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -17,7 +17,9 @@
   "learning.title.text.learning": "Lerninhalte",
   "learning.title.text.guides": "Interaktive Leitfäden",
   "learning.title.text.videos": "Video-Lernprogramme",
-  "samples.showsamples.text": "Beispiele in Ordner anzeigen",
+  "samples.showsamples.text": "Dateispeicherort öffnen",
+  "samples.showsamples.files.text": "Diagramme",
+  "samples.showsamples.datasets.text": "Datensätze",
   "main.page.loading.text": "Wird geladen",
   "recent.item.old.format": "Dynamo 1.x-Dateiformat",
   "recent.item.old.format.tooltip": "Für Dateien, die im Dynamo 1.x-Format gespeichert wurden, sind Autor und Miniaturansicht nicht verfügbar"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -17,7 +17,9 @@
     "learning.title.text.learning": "Learning",
     "learning.title.text.guides": "Interactive Guides",
     "learning.title.text.videos": "Video Tutorials",
-    "samples.showsamples.text": "Show Samples in Folder",
+    "samples.showsamples.text": "Open file location",
+    "samples.showsamples.files.text": "Graphs",
+    "samples.showsamples.datasets.text": "Datasets",
     "main.page.loading.text": "Loading",
     "recent.item.old.format": "Dynamo 1.x file format",
     "recent.item.old.format.tooltip": "Author and thumbnail not available for files saved in Dynamo 1.x format"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -17,7 +17,9 @@
   "learning.title.text.learning": "Formación",
   "learning.title.text.guides": "Guías interactivas",
   "learning.title.text.videos": "Aprendizajes en vídeo",
-  "samples.showsamples.text": "Mostrar muestras en carpeta",
+  "samples.showsamples.text": "Abrir ubicación del archivo",
+  "samples.showsamples.files.text": "Gráficos",
+  "samples.showsamples.datasets.text": "Conjuntos de datos",
   "main.page.loading.text": "Cargando",
   "recent.item.old.format": "Formato de archivo de Dynamo 1.x",
   "recent.item.old.format.tooltip": "Autor y miniatura no disponibles para los archivos guardados en el formato de Dynamo 1.x"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -17,7 +17,9 @@
   "learning.title.text.learning": "Formation",
   "learning.title.text.guides": "Guides interactifs",
   "learning.title.text.videos": "Didacticiels vidéo",
-  "samples.showsamples.text": "Afficher des exemples dans le dossier",
+  "samples.showsamples.text": "Ouvrir l'emplacement du fichier",
+  "samples.showsamples.files.text": "Graphiques",
+  "samples.showsamples.datasets.text": "Jeux de données",
   "main.page.loading.text": "Chargement",
   "recent.item.old.format": "Format de fichier Dynamo 1.x",
   "recent.item.old.format.tooltip": "L'auteur et la miniature ne sont pas disponibles pour les fichiers enregistrés au format Dynamo 1.x"

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -17,7 +17,9 @@
   "learning.title.text.learning": "Apprendimento",
   "learning.title.text.guides": "Guide interattive",
   "learning.title.text.videos": "Esercitazioni video",
-  "samples.showsamples.text": "Mostra esempi nella cartella",
+  "samples.showsamples.text": "Apri percorso file",
+  "samples.showsamples.files.text": "Grafici",
+  "samples.showsamples.datasets.text": "Set di dati",
   "main.page.loading.text": "Caricamento in corso",
   "recent.item.old.format": "Formato di file di Dynamo 1.x",
   "recent.item.old.format.tooltip": "Autore e anteprima non disponibili per i file salvati in formato di Dynamo 1.x"

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -17,7 +17,9 @@
   "learning.title.text.learning": "学習",
   "learning.title.text.guides": "インタラクティブ ガイド",
   "learning.title.text.videos": "ビデオ チュートリアル",
-  "samples.showsamples.text": "フォルダ内のサンプルを表示",
+  "samples.showsamples.text": "ファイルの場所を開",
+  "samples.showsamples.files.text": "グラフ",
+  "samples.showsamples.datasets.text": "データセット",
   "main.page.loading.text": "ロード中",
   "recent.item.old.format": "Dynamo 1.x ファイル形式",
   "recent.item.old.format.tooltip": "Dynamo 1.x 形式で保存されたファイルの作成者とサムネイルは使用できません"

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -17,7 +17,9 @@
   "learning.title.text.learning": "학습",
   "learning.title.text.guides": "대화식 안내서",
   "learning.title.text.videos": "비디오 튜토리얼",
-  "samples.showsamples.text": "폴더에 샘플 표시",
+  "samples.showsamples.text": "파일 위치 열기",
+  "samples.showsamples.files.text": "그래프",
+  "samples.showsamples.datasets.text": "데이터셋",
   "main.page.loading.text": "로드 중",
   "recent.item.old.format": "Dynamo 1.x 파일 형식",
   "recent.item.old.format.tooltip": "Dynamo 1.x 형식으로 저장된 파일에 대해서는 작성자 및 썸네일을 사용할 수 없습니다."

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -17,7 +17,9 @@
   "learning.title.text.learning": "Nauka",
   "learning.title.text.guides": "Interaktywne podręczniki",
   "learning.title.text.videos": "Filmy z samouczkami",
-  "samples.showsamples.text": "Pokaż przykłady w folderze",
+  "samples.showsamples.text": "Otwórz lokalizację pliku",
+  "samples.showsamples.files.text": "Wykresy",
+  "samples.showsamples.datasets.text": "Zbiory danych",
   "main.page.loading.text": "Wczytywanie",
   "recent.item.old.format": "Format pliku Dynamo 1.x",
   "recent.item.old.format.tooltip": "Informacje o autorze i miniatura nie są dostępne w przypadku plików zapisanych w formacie Dynamo 1.x"

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -17,7 +17,9 @@
   "learning.title.text.learning": "Aprendizagem",
   "learning.title.text.guides": "Guias interativos",
   "learning.title.text.videos": "Tutoriais em vídeo",
-  "samples.showsamples.text": "Mostrar amostras na pasta",
+  "samples.showsamples.text": "Abrir local do arquivo",
+  "samples.showsamples.files.text": "Gráficos",
+  "samples.showsamples.datasets.text": "Conjuntos de dados",
   "main.page.loading.text": "Carregando",
   "recent.item.old.format": "Formato de arquivo do Dynamo 1.x",
   "recent.item.old.format.tooltip": "Autor e miniatura não disponíveis para arquivos salvos no formato do Dynamo 1.x"

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -17,7 +17,9 @@
   "learning.title.text.learning": "Обучение",
   "learning.title.text.guides": "Интерактивные руководства",
   "learning.title.text.videos": "Учебные видеоролики",
-  "samples.showsamples.text": "Показать образцы в папке",
+  "samples.showsamples.text": "Открыть расположение файла",
+  "samples.showsamples.files.text": "Графики",
+  "samples.showsamples.datasets.text": "Наборы данных",
   "main.page.loading.text": "Загрузка",
   "recent.item.old.format": "Формат файлов Dynamo 1.x",
   "recent.item.old.format.tooltip": "Автор и миниатюра недоступны для файлов, сохраненных в формате Dynamo 1.x"

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -17,7 +17,9 @@
   "learning.title.text.learning": "正在学习",
   "learning.title.text.guides": "互动指南",
   "learning.title.text.videos": "视频教程",
-  "samples.showsamples.text": "在文件夹中显示样例",
+  "samples.showsamples.text": "打开文件位置",
+  "samples.showsamples.files.text": "图表",
+  "samples.showsamples.datasets.text": "数据集",
   "main.page.loading.text": "正在加载",
   "recent.item.old.format": "Dynamo 1.x 文件格式",
   "recent.item.old.format.tooltip": "作者和缩略图不适用于以 Dynamo 1.x 格式保存的文件"

--- a/src/locales/zh-Hant.json
+++ b/src/locales/zh-Hant.json
@@ -17,7 +17,9 @@
   "learning.title.text.learning": "學習",
   "learning.title.text.guides": "互動式指南",
   "learning.title.text.videos": "影片自學課程",
-  "samples.showsamples.text": "顯示資料夾中的範例",
+  "samples.showsamples.text": "打開檔案位置",
+  "samples.showsamples.files.text": "圖表",
+  "samples.showsamples.datasets.text": "數據集",
   "main.page.loading.text": "正在載入",
   "recent.item.old.format": "Dynamo 1.x 檔案格式",
   "recent.item.old.format.tooltip": "以 Dynamo 1.x 格式儲存的檔案沒有作者和縮圖"

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,6 +5,7 @@ declare module "*.module.css";
 type Locale = 'en' | 'en-US' | 'es-ES' | 'de-DE' | 'cs-CZ' | 'fr-FR' | 'it-IT' | 'ja-JP' | 'ko-KR' | 'pl-PL' | 'pt-BR' | 'ru-RU' | 'zh-Hans' | 'zh-Hant' | 'zh-CN' | 'zh-TW';
 type SidebarCommand = 'open-file' | 'open-template' | 'open-backup-locations' | 'workspace' | 'custom-node';
 type SidebarItem = 'Recent' | 'Samples' | 'Learning';
+type ShowSamplesCommand = 'open-graphs' | 'open-datasets';
 type HomePageSetting = { recentPageViewMode: 'grid' | 'list' | undefined, samplesViewMode: 'grid' | 'list' | undefined }
 interface Window {
   setLocale: (value: Locale) => void;


### PR DESCRIPTION
### Purpose
PR to address latest comments from https://jira.autodesk.com/browse/DYN-7330.
Adds a button for a dropdown to allow users to find Sample Graph folder and Sample Dataset. The button replaces the current "Show samples in folder button". The divider between the label an the arrow is removed and the whole button is actionable.


PR for on the dynamo side to follow soon.

![Screenshot 2024-09-12 182625](https://github.com/user-attachments/assets/fd1ff98d-5356-4bd4-a12e-33fbf5d44189)

### Reviewers
@QilongTang 
@reddyashish

### FYIs
@dnenov