### PR TITLE
[DYN-8864] As a Dynamo user, I want to see the full file name when I hover on file thumbnail in Dynamo Home App

### DIFF
--- a/src/components/Recent/GraphGridItem.tsx
+++ b/src/components/Recent/GraphGridItem.tsx
@@ -15,7 +15,13 @@ export const GraphGridItem = ({ id, Caption, ContextData, Description, DateModif
         <CardItem 
             imageSrc={Thumbnail || img} 
             onClick={handleClick} 
-            tooltipContent={Description} 
+            tooltipContent={
+                <>
+                <div>{Caption}</div>
+                <div>{ContextData}</div>
+                <div>{Description}</div>
+                </>
+                } 
             titleText={Caption} 
             subtitleText={DateModified} 
         />


### PR DESCRIPTION
This PR addresses [DYN-8864](https://jira.autodesk.com/browse/DYN-8864).

I've updated the `GraphGridItem` component to customize the tooltip. Now, when a user hovers over a graph thumbnail , the tooltip will display the graph’s title (Caption), file path (ContextData), and description, each on its own line.

![Screenshot 2025-05-09 185423](https://github.com/user-attachments/assets/03ae545d-460e-46f2-8fb5-6351ceb8f53f)

@reddyashish 
@zeusongit 

@achintyabhat 
@dnenov 