### PR TITLE
Clear Home loading overlay when deleted files are removed

### DIFF
--- a/src/components/Recent/PageRecent.tsx
+++ b/src/components/Recent/PageRecent.tsx
@@ -38,6 +38,7 @@ export const RecentPage = ({ setIsDisabled, recentPageViewMode }: RecentPage) =>
       // jsonData is already an object, so no need to parse it
       const data = jsonData;
       setGraphs(data);
+      setIsDisabled(false);
     } catch (error) {
       console.error('Error processing data:', error);
     }

--- a/src/components/TemplatesContext.tsx
+++ b/src/components/TemplatesContext.tsx
@@ -54,6 +54,7 @@ export const TemplatesProvider = ({ children }: TemplatesProviderProps) => {
           // jsonData is already an object, so no need to parse it
           const data = (jsonData || []).map(normalizeTemplate);
           setTemplates(data);
+          window.setShowStartPageChanged?.(true);
         } catch (error) {
           console.error('Error processing templates data:', error);
         }

--- a/tests/unit/Recent/PageRecent.test.tsx
+++ b/tests/unit/Recent/PageRecent.test.tsx
@@ -112,6 +112,14 @@ describe('RecentPage', () => {
     expect(screen.getByText('Graph Two')).toBeInTheDocument();
   });
 
+  it('window.receiveGraphDataFromDotNet clears loading state', () => {
+    renderWithProviders(<RecentPage {...defaultProps} recentPageViewMode="grid" />);
+    act(() => {
+      window.receiveGraphDataFromDotNet(mockGraphs);
+    });
+    expect(defaultProps.setIsDisabled).toHaveBeenCalledWith(false);
+  });
+
   it('receiveGraphDataFromDotNet with empty array does not crash', () => {
     renderWithProviders(<RecentPage {...defaultProps} />);
     expect(() => {

--- a/tests/unit/TemplatesContext.test.tsx
+++ b/tests/unit/TemplatesContext.test.tsx
@@ -1,0 +1,28 @@
+import { act, render } from '@testing-library/react';
+import { TemplatesProvider } from '../../src/components/TemplatesContext';
+
+describe('TemplatesProvider', () => {
+  beforeEach(() => {
+    window.setShowStartPageChanged = jest.fn();
+  });
+
+  afterEach(() => {
+    delete window.setShowStartPageChanged;
+    delete window.receiveTemplatesDataFromDotNet;
+    jest.clearAllMocks();
+  });
+
+  it('clears loading state when template data is received', () => {
+    render(
+      <TemplatesProvider>
+        <div />
+      </TemplatesProvider>
+    );
+
+    act(() => {
+      window.receiveTemplatesDataFromDotNet([]);
+    });
+
+    expect(window.setShowStartPageChanged).toHaveBeenCalledWith(true);
+  });
+});


### PR DESCRIPTION
### Purpose

This PR addresses [DYN-10516](https://autodesk.atlassian.net/browse/DYN-10516).

The changes in the code aim to clear the Home loading overlay when trying to open a deleted or moved Recent file or Template and sends refreshed data back to DynamoHome. Without this, Home remains stuck on “Loading” until the user switched away and returned.

This pr works with : https://github.com/DynamoDS/Dynamo/pull/17161

<img width="1280" height="720" alt="gif loading overlay" src="https://github.com/user-attachments/assets/a71fdfa1-e03e-4d78-9c14-90c4a23e71de" />

Changes :

- Clears the loading state when refreshed Recent file data is received from Dynamo.
- Clears the loading state when refreshed Template data is received from Dynamo.
- Added coverage for both loading-state clear behaviors.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Home no longer stays stuck on the loading screen after clicking a deleted or moved Recent file or Template.

The disk refresh and missing-file handling live in the Dynamo repo PR, this repo only fixes the WebView loading overlay on the DynamoHome side.

### Reviewers

@zeusongit
@DynamoDS/eidos


### FYIs

@dnenov
@johnpierson
@jnealb 
@jasonstratton 
