### PR TITLE
Added tests for the Templates flow

### DIFF
--- a/tests/unit/Recent/PageRecent.test.tsx
+++ b/tests/unit/Recent/PageRecent.test.tsx
@@ -1,6 +1,8 @@
 import { screen, fireEvent, act } from '@testing-library/react';
 import { renderWithProviders } from '../testUtils';
 import { RecentPage } from '../../../src/components/Recent/PageRecent';
+import { useTemplates } from '../../../src/components/TemplatesContext';
+import { openFile } from '../../../src/functions/utility';
 
 jest.mock('../../../src/components/Recent/GraphGridItem', () => ({
   GraphGridItem: (props: unknown) => {
@@ -12,8 +14,8 @@ jest.mock('../../../src/components/Recent/GraphGridItem', () => ({
 jest.mock('../../../src/components/Recent/GraphTable', () => ({
   GraphTable: (props: unknown) => {
     const { data, onRowClick } = props as {
-      data: Array<{ id: string; Caption: string }>;
-      onRowClick: (row: { original: { id: string; Caption: string } }) => void;
+      data: Array<{ id: string; Caption: string; ContextData: string }>;
+      onRowClick: (row: { original: { id: string; Caption: string; ContextData: string } }) => void;
     };
     return (
       <div data-testid="graph-table">
@@ -32,6 +34,10 @@ jest.mock('../../../src/functions/utility', () => ({
   saveHomePageSettings: jest.fn(),
 }));
 
+jest.mock('../../../src/components/TemplatesContext', () => ({
+  useTemplates: jest.fn(),
+}));
+
 const defaultProps = {
   setIsDisabled: jest.fn(),
   recentPageViewMode: 'grid' as const,
@@ -42,9 +48,24 @@ const mockGraphs = [
   { id: '2', Caption: 'Graph Two', ContextData: '/path/two.dyn', DateModified: '2024-01-02', Thumbnail: null, Description: '' },
 ];
 
+const mockTemplates = [
+  {
+    id: 'template-1',
+    Caption: 'Template One',
+    ContextData: '/path/template-one.dyn',
+    DateModified: '2024-02-01',
+    Thumbnail: '',
+    Author: '',
+    Description: '',
+  },
+];
+
+const mockUseTemplates = useTemplates as jest.MockedFunction<typeof useTemplates>;
+
 describe('RecentPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseTemplates.mockReturnValue([]);
   });
 
   it('renders "Recent" title', () => {
@@ -133,5 +154,34 @@ describe('RecentPage', () => {
     const { unmount } = renderWithProviders(<RecentPage {...defaultProps} />);
     unmount();
     expect(window.receiveGraphDataFromDotNet).toBeUndefined();
+  });
+
+  it('renders templates returned by TemplatesContext', () => {
+    mockUseTemplates.mockReturnValue(mockTemplates);
+    renderWithProviders(<RecentPage {...defaultProps} recentPageViewMode="grid" />);
+
+    expect(screen.getByText('Templates')).toBeInTheDocument();
+    expect(screen.getByText('Template One')).toBeInTheDocument();
+  });
+
+  it('switches templates to list view', () => {
+    mockUseTemplates.mockReturnValue(mockTemplates);
+    renderWithProviders(<RecentPage {...defaultProps} recentPageViewMode="grid" />);
+
+    fireEvent.click(screen.getByTestId('templates-view-toggle-list'));
+
+    expect(screen.getByTestId('graph-table')).toBeInTheDocument();
+    expect(screen.getByText('Template One')).toBeInTheDocument();
+  });
+
+  it('opens a template from the templates table', () => {
+    mockUseTemplates.mockReturnValue(mockTemplates);
+    renderWithProviders(<RecentPage {...defaultProps} recentPageViewMode="grid" />);
+
+    fireEvent.click(screen.getByTestId('templates-view-toggle-list'));
+    fireEvent.click(screen.getByText('Template One'));
+
+    expect(defaultProps.setIsDisabled).toHaveBeenCalledWith(true);
+    expect(openFile).toHaveBeenCalledWith('/path/template-one.dyn');
   });
 });

--- a/tests/unit/TemplatesContext.test.tsx
+++ b/tests/unit/TemplatesContext.test.tsx
@@ -1,5 +1,22 @@
-import { act, render } from '@testing-library/react';
-import { TemplatesProvider } from '../../src/components/TemplatesContext';
+import { act, render, screen } from '@testing-library/react';
+import { TemplatesProvider, useTemplates } from '../../src/components/TemplatesContext';
+
+const TemplatesConsumer = () => {
+  const templates = useTemplates();
+
+  return (
+    <div>
+      {templates.map((template) => (
+        <div key={template.id}>
+          <span>{template.Caption}</span>
+          <span>{`date:${template.DateModified}`}</span>
+          <span>{`author:${template.Author}`}</span>
+          <span>{`description:${template.Description}`}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
 
 describe('TemplatesProvider', () => {
   beforeEach(() => {
@@ -15,7 +32,7 @@ describe('TemplatesProvider', () => {
   it('clears loading state when template data is received', () => {
     render(
       <TemplatesProvider>
-        <div />
+        <TemplatesConsumer />
       </TemplatesProvider>
     );
 
@@ -24,5 +41,79 @@ describe('TemplatesProvider', () => {
     });
 
     expect(window.setShowStartPageChanged).toHaveBeenCalledWith(true);
+  });
+
+  it('registers receiveTemplatesDataFromDotNet on mount', () => {
+    render(
+      <TemplatesProvider>
+        <TemplatesConsumer />
+      </TemplatesProvider>
+    );
+
+    expect(typeof window.receiveTemplatesDataFromDotNet).toBe('function');
+  });
+
+  it('updates templates from receiveTemplatesDataFromDotNet', () => {
+    render(
+      <TemplatesProvider>
+        <TemplatesConsumer />
+      </TemplatesProvider>
+    );
+
+    act(() => {
+      window.receiveTemplatesDataFromDotNet([
+        {
+          id: 'template-1',
+          Caption: 'Template One',
+          ContextData: '/path/template-one.dyn',
+          DateModified: '2024-02-01',
+          Thumbnail: '',
+          Author: 'Dynamo Team',
+          Description: 'Template description',
+        },
+      ]);
+    });
+
+    expect(screen.getByText('Template One')).toBeInTheDocument();
+    expect(screen.getByText('date:2024-02-01')).toBeInTheDocument();
+    expect(screen.getByText('author:Dynamo Team')).toBeInTheDocument();
+    expect(screen.getByText('description:Template description')).toBeInTheDocument();
+  });
+
+  it('normalizes date, Author, and Description fields from template input', () => {
+    render(
+      <TemplatesProvider>
+        <TemplatesConsumer />
+      </TemplatesProvider>
+    );
+
+    act(() => {
+      window.receiveTemplatesDataFromDotNet([
+        {
+          id: 'template-1',
+          Caption: 'Template One',
+          ContextData: '/path/template-one.dyn',
+          date: '2024-03-01',
+          Thumbnail: '',
+        },
+      ]);
+    });
+
+    expect(screen.getByText('Template One')).toBeInTheDocument();
+    expect(screen.getByText('date:2024-03-01')).toBeInTheDocument();
+    expect(screen.getByText('author:')).toBeInTheDocument();
+    expect(screen.getByText('description:')).toBeInTheDocument();
+  });
+
+  it('removes receiveTemplatesDataFromDotNet on unmount', () => {
+    const { unmount } = render(
+      <TemplatesProvider>
+        <TemplatesConsumer />
+      </TemplatesProvider>
+    );
+
+    unmount();
+
+    expect(window.receiveTemplatesDataFromDotNet).toBeUndefined();
   });
 });


### PR DESCRIPTION
### Purpose

This PR addresses [DYN-9702](https://autodesk.atlassian.net/browse/DYN-9702). 

After [DYN-9702](https://github.com/DynamoDS/DynamoHome/pull/89) was merged, additional tests were still needed for the Templates functionality added to PageRecent.tsx and for the new TemplatesContext.tsx file. This PR adds that missing tests coverage.

This update adds focused test coverage for the template support introduced in DYN-9702. The tests cover how template data is received from Dynamo, exposed through TemplatesContext, normalized for use by the existing grid/table components, and displayed/opened from PageRecent.

changes : 

Added additional TemplatesContext unit tests for:
- registering the Dynamo template callback
- receiving template data from Dynamo
- normalizing date to DateModified
- defaulting missing Author and Description
- cleaning up the callback when the provider is removed

Extended PageRecent unit tests for:
- rendering templates from context
- switching the Templates section from grid view to list view
- opening a clicked template through openFile

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Added unit test coverage for the Dynamo Home Templates flow introduced in DYN-9702.

### Reviewers

@zeusongit
@DynamoDS/eidos


### FYIs

@dnenov
@johnpierson
@jnealb 
@jasonstratton 